### PR TITLE
Allow connecting to IPv4 addresses

### DIFF
--- a/host.c
+++ b/host.c
@@ -49,6 +49,8 @@ enet_host_create (const ENetAddress * address, size_t peerCount, size_t channelL
     memset (host -> peers, 0, peerCount * sizeof (ENetPeer));
 
     host -> socket = enet_socket_create (ENET_SOCKET_TYPE_DATAGRAM);
+	if( host -> socket > ENET_SOCKET_NULL )
+		enet_socket_set_option (host -> socket, ENET_SOCKOPT_IPV6_V6ONLY, 0);
     if (host -> socket == ENET_SOCKET_NULL || (address != NULL && enet_socket_bind (host -> socket, address) < 0))
     {
        if (host -> socket != ENET_SOCKET_NULL)
@@ -64,7 +66,6 @@ enet_host_create (const ENetAddress * address, size_t peerCount, size_t channelL
     enet_socket_set_option (host -> socket, ENET_SOCKOPT_BROADCAST, 1);
     enet_socket_set_option (host -> socket, ENET_SOCKOPT_RCVBUF, ENET_HOST_RECEIVE_BUFFER_SIZE);
     enet_socket_set_option (host -> socket, ENET_SOCKOPT_SNDBUF, ENET_HOST_SEND_BUFFER_SIZE);
-    enet_socket_set_option (host -> socket, ENET_SOCKOPT_IPV6_V6ONLY, 0);
 
 
     if (address != NULL && enet_socket_get_address (host -> socket, & host -> address) < 0)   

--- a/unix.c
+++ b/unix.c
@@ -147,7 +147,7 @@ enet_address_set_host (ENetAddress * address, const char * name)
     hostEntry = gethostbyname (name);
 #endif
 
-    if (hostEntry != NULL && hostEntry -> h_addrtype == AF_INET)
+    if (hostEntry != NULL && hostEntry -> h_addrtype == AF_INET6)
     {
         address -> host = *(struct in6_addr *) hostEntry -> h_addr_list [0];
 

--- a/unix.c
+++ b/unix.c
@@ -131,6 +131,7 @@ enet_address_set_host (ENetAddress * address, const char * name)
     if (resultList != NULL)
       freeaddrinfo (resultList);
 #else
+#warning "Really use gethostbyname() with IPv6? Not all platforms support it."
     struct hostent * hostEntry = NULL;
 #ifdef HAS_GETHOSTBYNAME_R
     struct hostent hostData;
@@ -157,6 +158,7 @@ enet_address_set_host (ENetAddress * address, const char * name)
 #ifdef HAS_INET_PTON
     if (! inet_pton (AF_INET6, name, & address -> host))
 #else
+#error "inet_pton() is needed for IPv6 support"
     if (! inet_aton (name, (struct in_addr *) & address -> host))
 #endif
         return -1;
@@ -170,6 +172,7 @@ enet_address_get_host_ip (const ENetAddress * address, char * name, size_t nameL
 #ifdef HAS_INET_NTOP
     if (inet_ntop (AF_INET6, & address -> host, name, nameLength) == NULL)
 #else
+#error "inet_ntop() is needed for IPv6 support"
     char * addr = inet_ntoa (* (struct in_addr *) & address -> host);
     if (addr != NULL)
     {
@@ -208,6 +211,7 @@ enet_address_get_host (const ENetAddress * address, char * name, size_t nameLeng
     if (err != EAI_NONAME)
       return 0;
 #else
+#warning "Really use gethostbyaddr() with IPv6? Not all platforms support it."
     struct in6_addr in;
     struct hostent * hostEntry = NULL;
 #ifdef HAS_GETHOSTBYADDR_R


### PR DESCRIPTION
2b52599: I implemented the "todo" in enet_address_set_host() in unix.c:118.
2a567b0: The socket-option ENET_SOCKOPT_IPV6_V6ONLY needs to be set before bind(), otherwise it returns an error.
a91524f: The wrong address-family was used
90620b2: Just some compiler warnings/errors, when the defines from configure are not set correctly
